### PR TITLE
Fix rsync

### DIFF
--- a/slash/include/base_conf.h
+++ b/slash/include/base_conf.h
@@ -16,8 +16,40 @@
 
 namespace slash {
 
+class BaseConf;
+
+
 class BaseConf {
  public:
+  struct Rep {
+    std::string path;
+    enum ConfType {
+      kConf = 0,
+      kComment = 1,
+    };
+
+    struct ConfItem {
+      ConfType type; // 0 means conf, 1 means comment
+      std::string name;
+      std::string value;
+      ConfItem(ConfType t, const std::string &v) :
+        type(t),
+        name(""),
+        value(v)
+      {}
+      ConfItem(ConfType t, const std::string &n, const std::string &v) :
+        type(t),
+        name(n),
+        value(v)
+      {}
+    };
+
+    explicit Rep(const std::string &p)
+      : path(p) {
+    }
+    std::vector<ConfItem> item;
+  };
+
   explicit BaseConf(const std::string &path);
   virtual ~BaseConf();
 
@@ -43,8 +75,9 @@ class BaseConf {
   bool WriteBack();
   void WriteSampleConf() const;
 
+  void PushConfItem(const Rep::ConfItem& item);
+
  private:
-  struct Rep;
   Rep* rep_;
 
   /*

--- a/slash/include/base_conf.h
+++ b/slash/include/base_conf.h
@@ -71,6 +71,8 @@ class BaseConf {
   bool SetConfBool(const std::string &name, const bool value);
   bool SetConfStrVec(const std::string &name, const std::vector<std::string> &value);
 
+  bool CheckConfExist(const std::string &name) const;
+
   void DumpConf() const;
   bool WriteBack();
   void WriteSampleConf() const;

--- a/slash/include/lock_mgr.h
+++ b/slash/include/lock_mgr.h
@@ -1,0 +1,60 @@
+//  Copyright (c) 2017-present The blackwidow Authors.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef SRC_LOCK_MGR_H_
+#define SRC_LOCK_MGR_H_
+
+#include <string>
+#include <memory>
+
+#include "slash/include/mutex.h"
+
+namespace slash {
+
+namespace lock {
+struct LockMap;
+struct LockMapStripe;
+
+class LockMgr {
+ public:
+  LockMgr(size_t default_num_stripes, int64_t max_num_locks,
+          std::shared_ptr<MutexFactory> factory);
+
+  ~LockMgr();
+
+  // Attempt to lock key.  If OK status is returned, the caller is responsible
+  // for calling UnLock() on this key.
+  Status TryLock(const std::string& key);
+
+  // Unlock a key locked by TryLock().
+  void UnLock(const std::string& key);
+
+ private:
+  // Default number of lock map stripes
+  const size_t default_num_stripes_;
+
+  // Limit on number of keys locked per column family
+  const int64_t max_num_locks_;
+
+  // Used to allocate mutexes/condvars to use when locking keys
+  std::shared_ptr<MutexFactory> mutex_factory_;
+
+  // Map to locked key info
+  std::shared_ptr<LockMap> lock_map_;
+
+  Status Acquire(LockMapStripe* stripe, const std::string& key);
+
+  Status AcquireLocked(LockMapStripe* stripe, const std::string& key);
+
+  void UnLockKey(const std::string& key, LockMapStripe* stripe);
+
+  // No copying allowed
+  LockMgr(const LockMgr&);
+  void operator=(const LockMgr&);
+};
+
+}  //  namespace lock
+}  //  namespace slash
+#endif  // SRC_LOCK_MGR_H_

--- a/slash/include/mutex.h
+++ b/slash/include/mutex.h
@@ -1,0 +1,89 @@
+//  Copyright (c) 2017-present The blackwidow Authors.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef SRC_MUTEX_H_
+#define SRC_MUTEX_H_
+
+#include <memory>
+
+#include "slash/include/slash_status.h"
+
+namespace slash {
+
+namespace lock {
+
+using Status = slash::Status;
+
+class Mutex {
+ public:
+  virtual ~Mutex() {}
+
+  // Attempt to acquire lock.  Return OK on success, or other Status on failure.
+  // If returned status is OK, BlackWidow will eventually call UnLock().
+  virtual Status Lock() = 0;
+
+  // Attempt to acquire lock.  If timeout is non-negative, operation may be
+  // failed after this many microseconds.
+  // Returns OK on success,
+  //         TimedOut if timed out,
+  //         or other Status on failure.
+  // If returned status is OK, BlackWidow will eventually call UnLock().
+  virtual Status TryLockFor(int64_t timeout_time) = 0;
+
+  // Unlock Mutex that was successfully locked by Lock() or TryLockUntil()
+  virtual void UnLock() = 0;
+};
+
+class CondVar {
+ public:
+  virtual ~CondVar() {}
+
+  // Block current thread until condition variable is notified by a call to
+  // Notify() or NotifyAll().  Wait() will be called with mutex locked.
+  // Returns OK if notified.
+  // Returns non-OK if BlackWidow should stop waiting and fail the operation.
+  // May return OK spuriously even if not notified.
+  virtual Status Wait(std::shared_ptr<Mutex> mutex) = 0;
+
+  // Block current thread until condition variable is notified by a call to
+  // Notify() or NotifyAll(), or if the timeout is reached.
+  // Wait() will be called with mutex locked.
+  //
+  // If timeout is non-negative, operation should be failed after this many
+  // microseconds.
+  // If implementing a custom version of this class, the implementation may
+  // choose to ignore the timeout.
+  //
+  // Returns OK if notified.
+  // Returns TimedOut if timeout is reached.
+  // Returns other status if BlackWidow should otherwis stop waiting and
+  //  fail the operation.
+  // May return OK spuriously even if not notified.
+  virtual Status WaitFor(std::shared_ptr<Mutex> mutex,
+                         int64_t timeout_time) = 0;
+
+  // If any threads are waiting on *this, unblock at least one of the
+  // waiting threads.
+  virtual void Notify() = 0;
+
+  // Unblocks all threads waiting on *this.
+  virtual void NotifyAll() = 0;
+};
+
+// Factory class that can allocate mutexes and condition variables.
+class MutexFactory {
+ public:
+  // Create a Mutex object.
+  virtual std::shared_ptr<Mutex> AllocateMutex() = 0;
+
+  // Create a CondVar object.
+  virtual std::shared_ptr<CondVar> AllocateCondVar() = 0;
+
+  virtual ~MutexFactory() {}
+};
+
+}  // namespace lock
+}  // namespace slash
+#endif  // SRC_MUTEX_H_

--- a/slash/include/mutex_impl.h
+++ b/slash/include/mutex_impl.h
@@ -1,0 +1,23 @@
+//  Copyright (c) 2017-present The blackwidow Authors.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef SRC_MUTEX_IMPL_H_
+#define SRC_MUTEX_IMPL_H_
+
+#include "slash/include/mutex.h"
+
+#include <memory>
+
+namespace slash {
+namespace lock {
+// Default implementation of MutexFactory.
+class MutexFactoryImpl : public MutexFactory {
+ public:
+  std::shared_ptr<Mutex> AllocateMutex() override;
+  std::shared_ptr<CondVar> AllocateCondVar() override;
+};
+}  //  namespace lock
+}  //  namespace slash
+#endif  // SRC_MUTEX_IMPL_H_

--- a/slash/include/rsync.h
+++ b/slash/include/rsync.h
@@ -4,11 +4,13 @@
 #include <string>
 
 namespace slash {
+const std::string kRsyncSecretFile = "slash_rsync.secret";
 const std::string kRsyncConfFile = "slash_rsync.conf";
 const std::string kRsyncLogFile = "slash_rsync.log";
 const std::string kRsyncPidFile = "slash_rsync.pid";
 const std::string kRsyncLockFile = "slash_rsync.lock";
 const std::string kRsyncSubDir = "rsync";
+const std::string kRsyncUser = "rsync_user";
 struct RsyncRemote {
   std::string host;
   int port;
@@ -19,12 +21,12 @@ struct RsyncRemote {
   : host(_host), port(_port), module(_module), kbps(_kbps) {}
 };
 
-int StartRsync(const std::string& rsync_path, const std::string& module, const std::string& ip, const int port);
+int StartRsync(const std::string& rsync_path, const std::string& module, const std::string& ip, const int port, const std::string& passwd);
 int StopRsync(const std::string& path);
 int RsyncSendFile(const std::string& local_file_path, const std::string& remote_file_path,
-    const RsyncRemote& remote);
+    const std::string& secret_file_path, const RsyncRemote& remote);
 int RsyncSendClearTarget(const std::string& local_dir_path, const std::string& remote_dir_path,
-    const RsyncRemote& remote);
+    const std::string& secret_file_path, const RsyncRemote& remote);
 
 }
 #endif

--- a/slash/include/scope_record_lock.h
+++ b/slash/include/scope_record_lock.h
@@ -1,0 +1,66 @@
+//  Copyright (c) 2017-present The blackwidow Authors.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef SRC_SCOPE_RECORD_LOCK_H_
+#define SRC_SCOPE_RECORD_LOCK_H_
+
+#include <vector>
+#include <string>
+#include <algorithm>
+
+#include "slash/include/lock_mgr.h"
+
+namespace slash {
+
+namespace lock {
+
+class ScopeRecordLock {
+ public:
+  ScopeRecordLock(LockMgr* lock_mgr, const Slice& key) :
+    lock_mgr_(lock_mgr), key_(key) {
+    lock_mgr_->TryLock(key_.ToString());
+  }
+  ~ScopeRecordLock() {
+    lock_mgr_->UnLock(key_.ToString());
+  }
+
+ private:
+  LockMgr* const lock_mgr_;
+  Slice key_;
+  ScopeRecordLock(const ScopeRecordLock&);
+  void operator=(const ScopeRecordLock&);
+};
+
+class MultiScopeRecordLock {
+ public:
+  MultiScopeRecordLock(LockMgr* lock_mgr,
+      const std::vector<std::string>& keys);
+  ~MultiScopeRecordLock();
+
+ private:
+  LockMgr* const lock_mgr_;
+  std::vector<std::string> keys_;
+  MultiScopeRecordLock(const MultiScopeRecordLock&);
+  void operator=(const MultiScopeRecordLock&);
+};
+
+class MultiRecordLock {
+ public:
+  explicit MultiRecordLock(LockMgr* lock_mgr) : lock_mgr_(lock_mgr) {
+  }
+  ~MultiRecordLock() {
+  }
+  void Lock(const std::vector<std::string>& keys);
+  void Unlock(const std::vector<std::string>& keys);
+
+ private:
+  LockMgr* const lock_mgr_;
+  MultiRecordLock(const MultiRecordLock&);
+  void operator=(const MultiRecordLock&);
+};
+
+}  // namespace lock
+}  // namespace slash
+#endif  // SRC_SCOPE_RECORD_LOCK_H_

--- a/slash/include/slash_coding.h
+++ b/slash/include/slash_coding.h
@@ -19,12 +19,14 @@
 namespace slash {
 
 // Standard Put... routines append to a string
+extern void PutFixed16(std::string* dst, uint16_t value);
 extern void PutFixed32(std::string* dst, uint32_t value);
 extern void PutFixed64(std::string* dst, uint64_t value);
 extern void PutVarint32(std::string* dst, uint32_t value);
 extern void PutVarint64(std::string* dst, uint64_t value);
 extern void PutLengthPrefixedString(std::string* dst, const std::string& value);
 
+extern void GetFixed16(std::string* dst, uint16_t* value);
 extern void GetFixed32(std::string* dst, uint32_t* value);
 extern void GetFixed64(std::string* dst, uint64_t* value);
 extern bool GetVarint32(std::string* input, uint32_t* value);
@@ -46,6 +48,7 @@ extern int VarintLength(uint64_t v);
 
 // Lower-level versions of Put... that write directly into a character buffer
 // REQUIRES: dst has enough space for the value being written
+extern void EncodeFixed16(char* dst, uint16_t value);
 extern void EncodeFixed32(char* dst, uint32_t value);
 extern void EncodeFixed64(char* dst, uint64_t value);
 
@@ -57,6 +60,13 @@ extern char* EncodeVarint64(char* dst, uint64_t value);
 
 // Lower-level versions of Get... that read directly from a character buffer
 // without any bounds checking.
+
+inline uint16_t DecodeFixed16(const char* ptr) {
+    // Load the raw bytes
+    uint16_t result;
+    memcpy(&result, ptr, sizeof(result));  // gcc optimizes this to a plain load
+    return result;
+}
 
 inline uint32_t DecodeFixed32(const char* ptr) {
     // Load the raw bytes
@@ -70,6 +80,11 @@ inline uint64_t DecodeFixed64(const char* ptr) {
     uint64_t result;
     memcpy(&result, ptr, sizeof(result));  // gcc optimizes this to a plain load
     return result;
+}
+
+inline void GetFixed16(std::string* dst, uint16_t *value) {
+  *value = DecodeFixed16(dst->data());
+  dst->erase(0, sizeof(uint16_t));
 }
 
 inline void GetFixed32(std::string* dst, uint32_t *value) {

--- a/slash/include/slash_mutex.h
+++ b/slash/include/slash_mutex.h
@@ -33,14 +33,19 @@ class RWLock {
   RWLock(pthread_rwlock_t *mu, bool is_rwlock) :
     mu_(mu) {
       if (is_rwlock) {
-        pthread_rwlock_wrlock(this->mu_);
+        res = pthread_rwlock_wrlock(this->mu_);
       } else {
-        pthread_rwlock_rdlock(this->mu_);
+        res = pthread_rwlock_rdlock(this->mu_);
       }
     }
-  ~RWLock() { pthread_rwlock_unlock(this->mu_); }
+  ~RWLock() {
+    if (!res) {
+      pthread_rwlock_unlock(this->mu_);
+    }
+  }
 
  private:
+  int res;
   pthread_rwlock_t *const mu_;
   // No copying allowed
   RWLock(const RWLock&);

--- a/slash/include/slash_mutex.h
+++ b/slash/include/slash_mutex.h
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace slash {
 
@@ -168,7 +169,9 @@ public:
   RecordMutex() {};
   ~RecordMutex();
 
+  void MultiLock(const std::vector<std::string>& keys);
   void Lock(const std::string &key);
+  void MultiUnlock(const std::vector<std::string>& keys);
   void Unlock(const std::string &key);
 
 private:

--- a/slash/include/slash_status.h
+++ b/slash/include/slash_status.h
@@ -55,6 +55,10 @@ class Status {
     return Status(kAuthFailed, msg, msg2);
   }
 
+  static Status Busy(const Slice& msg, const Slice& msg2 = Slice()) {
+    return Status(kBusy, msg, msg2);
+  }
+
   // Returns true if the status indicates success.
   bool ok() const { return (state_ == NULL); }
 
@@ -88,6 +92,9 @@ class Status {
   // Returns true if the status is AuthFailed
   bool IsAuthFailed() const { return code() == kAuthFailed; }
 
+  // Return true if the status is Busy
+  bool IsBusy() const { return code() == kBusy; }
+
   // Return a string representation of this status suitable for printing.
   // Returns the string "OK" for success.
   std::string ToString() const;
@@ -111,7 +118,8 @@ class Status {
     kIncomplete = 7,
     kComplete = 8,
     kTimeout = 9,
-    kAuthFailed = 10
+    kAuthFailed = 10,
+    kBusy = 11
   };
 
   Code code() const {

--- a/slash/include/slash_string.h
+++ b/slash/include/slash_string.h
@@ -52,6 +52,7 @@ std::vector<std::string> &StringSplit(const std::string &s,
         char delim, std::vector<std::string> &elems);
 std::string StringConcat(const std::vector<std::string> &elems, char delim);
 std::string& StringToLower(std::string& ori);
+std::string& StringToUpper(std::string& ori);
 std::string IpPortString(const std::string& ip, int port);
 std::string ToRead(const std::string& str);
 bool ParseIpPortString(const std::string& ip_port, std::string& ip, int &port);

--- a/slash/include/slash_string.h
+++ b/slash/include/slash_string.h
@@ -46,6 +46,7 @@ long long memtoll(const char *p, int *err);
 int ll2string(char *s, size_t len, long long value);
 int string2ll(const char *s, size_t slen, long long *value);
 int string2l(const char *s, size_t slen, long *value);
+int string2ul(const char *s, size_t slen, unsigned long *value);
 int d2string(char *buf, size_t len, double value);
 int string2d(const char *buf, size_t len, double *value);
 std::vector<std::string> &StringSplit(const std::string &s,

--- a/slash/src/base_conf.cc
+++ b/slash/src/base_conf.cc
@@ -16,36 +16,6 @@ namespace slash {
 
 static const int kConfItemLen = 1024*1024;
 
-struct BaseConf::Rep {
-  std::string path;
-  enum ConfType {
-    kConf = 0,
-
-    kComment = 1,
-  };
-
-  struct ConfItem {
-    ConfType type; // 0 means conf, 1 means comment
-    std::string name;
-    std::string value;
-    ConfItem(ConfType t, const std::string &v) :
-      type(t),
-      name(""),
-      value(v)
-    {}
-    ConfItem(ConfType t, const std::string &n, const std::string &v) :
-      type(t),
-      name(n),
-      value(v)
-    {}
-  };
-
-  explicit Rep(const std::string &p)
-    : path(p) {
-    }
-  std::vector<ConfItem> item;
-};
-
 BaseConf::BaseConf(const std::string &path)
   : rep_(new Rep(path)) {
 }
@@ -309,6 +279,10 @@ void BaseConf::WriteSampleConf() const {
   }
   delete write_file;
   return;
+}
+
+void BaseConf::PushConfItem(const Rep::ConfItem& item) {
+  rep_->item.push_back(item);
 }
 
 }   // namespace slash

--- a/slash/src/base_conf.cc
+++ b/slash/src/base_conf.cc
@@ -235,6 +235,18 @@ bool BaseConf::SetConfStrVec(const std::string& name, const std::vector<std::str
   return SetConfStr(name, value_str);
 }
 
+bool BaseConf::CheckConfExist(const std::string& name) const {
+  for (size_t i = 0; i < rep_->item.size(); i++) {
+    if (rep_->item[i].type == Rep::kComment) {
+      continue;
+    }
+    if (name == rep_->item[i].name) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void BaseConf::DumpConf() const {
   int cnt = 1;
   for (size_t i = 0; i < rep_->item.size(); i++) {

--- a/slash/src/base_conf.cc
+++ b/slash/src/base_conf.cc
@@ -77,7 +77,7 @@ int BaseConf::LoadConf() {
     type = Rep::kComment;
     line_len = strlen(line);
     for (int i = 0; i < line_len; i++) {
-      if (line[i] == COMMENT) {
+      if (i == 0 && line[i] == COMMENT) {
         type = Rep::kComment;
         break;
       }

--- a/slash/src/env.cc
+++ b/slash/src/env.cc
@@ -759,7 +759,7 @@ Status NewSequentialFile(const std::string& fname, SequentialFile** result) {
 
 Status NewWritableFile(const std::string& fname, WritableFile** result) {
   Status s;
-  const int fd = open(fname.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+  const int fd = open(fname.c_str(), O_CREAT | O_RDWR | O_TRUNC | O_CLOEXEC, 0644);
   if (fd < 0) {
     *result = NULL;
     s = IOError(fname, errno);
@@ -771,7 +771,7 @@ Status NewWritableFile(const std::string& fname, WritableFile** result) {
 
 Status NewRWFile(const std::string& fname, RWFile** result) {
   Status s;
-  const int fd = open(fname.c_str(), O_CREAT | O_RDWR, 0644);
+  const int fd = open(fname.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0644);
   if (fd < 0) {
     *result = NULL;
     s = IOError(fname, errno);
@@ -783,7 +783,7 @@ Status NewRWFile(const std::string& fname, RWFile** result) {
 
 Status AppendWritableFile(const std::string& fname, WritableFile** result, uint64_t write_len) {
   Status s;
-  const int fd = open(fname.c_str(), O_RDWR, 0644);
+  const int fd = open(fname.c_str(), O_RDWR | O_CLOEXEC, 0644);
   if (fd < 0) {
     *result = NULL;
     s = IOError(fname, errno);

--- a/slash/src/lock_mgr.cc
+++ b/slash/src/lock_mgr.cc
@@ -1,0 +1,192 @@
+//  Copyright (c) 2017-present The blackwidow Authors.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include "slash/include/lock_mgr.h"
+
+#include <vector>
+#include <unordered_set>
+#include <atomic>
+#include <memory>
+#include <functional>
+
+#include "slash/include/mutex.h"
+
+namespace slash {
+
+namespace lock {
+
+struct LockMapStripe {
+  explicit LockMapStripe(std::shared_ptr<MutexFactory> factory) {
+    stripe_mutex = factory->AllocateMutex();
+    stripe_cv = factory->AllocateCondVar();
+    assert(stripe_mutex);
+    assert(stripe_cv);
+  }
+
+  // Mutex must be held before modifying keys map
+  std::shared_ptr<Mutex> stripe_mutex;
+
+  // Condition Variable per stripe for waiting on a lock
+  std::shared_ptr<CondVar> stripe_cv;
+
+  // Locked keys
+  std::unordered_set<std::string> keys;
+};
+
+// Map of #num_stripes LockMapStripes
+struct LockMap {
+  explicit LockMap(size_t num_stripes,
+                   std::shared_ptr<MutexFactory> factory)
+      : num_stripes_(num_stripes) {
+    lock_map_stripes_.reserve(num_stripes);
+    for (size_t i = 0; i < num_stripes; i++) {
+      LockMapStripe* stripe = new LockMapStripe(factory);
+      lock_map_stripes_.push_back(stripe);
+    }
+  }
+
+  ~LockMap() {
+    for (auto stripe : lock_map_stripes_) {
+      delete stripe;
+    }
+  }
+
+  // Number of sepearate LockMapStripes to create, each with their own Mutex
+  const size_t num_stripes_;
+
+  // Count of keys that are currently locked.
+  // (Only maintained if LockMgr::max_num_locks_ is positive.)
+  std::atomic<int64_t> lock_cnt{0};
+
+  std::vector<LockMapStripe*> lock_map_stripes_;
+
+  size_t GetStripe(const std::string& key) const;
+};
+
+size_t LockMap::GetStripe(const std::string& key) const {
+  assert(num_stripes_ > 0);
+  size_t stripe = std::hash<std::string>{}(key) % num_stripes_;
+  return stripe;
+}
+
+LockMgr::LockMgr(size_t default_num_stripes,
+                 int64_t max_num_locks,
+                 std::shared_ptr<MutexFactory> mutex_factory)
+    : default_num_stripes_(default_num_stripes),
+      max_num_locks_(max_num_locks),
+      mutex_factory_(mutex_factory),
+      lock_map_(std::shared_ptr<LockMap>(
+            new LockMap(default_num_stripes, mutex_factory))) {}
+
+LockMgr::~LockMgr() {}
+
+Status LockMgr::TryLock(const std::string& key) {
+#ifdef LOCKLESS
+  return Status::OK();
+#else
+  size_t stripe_num = lock_map_->GetStripe(key);
+  assert(lock_map_->lock_map_stripes_.size() > stripe_num);
+  LockMapStripe* stripe = lock_map_->lock_map_stripes_.at(stripe_num);
+
+  return Acquire(stripe, key);
+#endif
+}
+
+// Helper function for TryLock().
+Status LockMgr::Acquire(LockMapStripe* stripe,
+                        const std::string& key) {
+  Status result;
+
+  // we wait indefinitely to acquire the lock
+  result = stripe->stripe_mutex->Lock();
+
+  if (!result.ok()) {
+    // failed to acquire mutex
+    return result;
+  }
+
+  // Acquire lock if we are able to
+  result = AcquireLocked(stripe, key);
+
+  if (!result.ok()) {
+    // If we weren't able to acquire the lock, we will keep retrying
+    do {
+      result = stripe->stripe_cv->Wait(stripe->stripe_mutex);
+      if (result.ok()) {
+        result = AcquireLocked(stripe, key);
+      }
+    } while (!result.ok());
+  }
+
+  stripe->stripe_mutex->UnLock();
+
+  return result;
+}
+
+// Try to lock this key after we have acquired the mutex.
+// REQUIRED:  Stripe mutex must be held.
+Status LockMgr::AcquireLocked(LockMapStripe* stripe,
+                              const std::string& key) {
+  Status result;
+  // Check if this key is already locked
+  if (stripe->keys.find(key) != stripe->keys.end()) {
+    // Lock already held
+      result = Status::Busy("LockTimeout");
+  } else {  // Lock not held.
+    // Check lock limit
+    if (max_num_locks_ > 0 &&
+        lock_map_->lock_cnt.load(std::memory_order_acquire) >= max_num_locks_) {
+      result = Status::Busy("LockLimit");
+    } else {
+      // acquire lock
+      stripe->keys.insert(key);
+
+      // Maintain lock count if there is a limit on the number of locks
+      if (max_num_locks_) {
+        lock_map_->lock_cnt++;
+      }
+    }
+  }
+
+  return result;
+}
+
+void LockMgr::UnLockKey(const std::string& key, LockMapStripe* stripe) {
+#ifdef LOCKLESS
+#else
+  auto stripe_iter = stripe->keys.find(key);
+  if (stripe_iter != stripe->keys.end()) {
+    // Found the key locked.  unlock it.
+    stripe->keys.erase(stripe_iter);
+    if (max_num_locks_ > 0) {
+      // Maintain lock count if there is a limit on the number of locks.
+      assert(lock_map_->lock_cnt.load(std::memory_order_relaxed) > 0);
+      lock_map_->lock_cnt--;
+    }
+  } else {
+    // This key is either not locked or locked by someone else.
+  }
+#endif
+}
+
+void LockMgr::UnLock(const std::string& key) {
+  // Lock the mutex for the stripe that this key hashes to
+  size_t stripe_num = lock_map_->GetStripe(key);
+  assert(lock_map_->lock_map_stripes_.size() > stripe_num);
+  LockMapStripe* stripe = lock_map_->lock_map_stripes_.at(stripe_num);
+
+  stripe->stripe_mutex->Lock();
+  UnLockKey(key, stripe);
+  stripe->stripe_mutex->UnLock();
+
+  // Signal waiting threads to retry locking
+  stripe->stripe_cv->NotifyAll();
+}
+}  //  namespace lock
+}  //  namespace slash

--- a/slash/src/mutex_impl.cc
+++ b/slash/src/mutex_impl.cc
@@ -1,0 +1,130 @@
+//  Copyright (c) 2017-present The blackwidow Authors.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+
+#include <condition_variable>
+#include <memory>
+
+#include "slash/include/mutex.h"
+#include "slash/include/mutex_impl.h"
+
+namespace slash {
+namespace lock {
+
+class MutexImpl : public Mutex {
+ public:
+  MutexImpl() {}
+  ~MutexImpl() {}
+
+  Status Lock() override;
+
+  Status TryLockFor(int64_t timeout_time) override;
+
+  void UnLock() override { mutex_.unlock(); }
+
+  friend class CondVarImpl;
+
+ private:
+  std::mutex mutex_;
+};
+
+class CondVarImpl : public CondVar {
+ public:
+  CondVarImpl() {}
+  ~CondVarImpl() {}
+
+  Status Wait(std::shared_ptr<Mutex> mutex) override;
+
+  Status WaitFor(std::shared_ptr<Mutex> mutex,
+                 int64_t timeout_time) override;
+
+  void Notify() override { cv_.notify_one(); }
+
+  void NotifyAll() override { cv_.notify_all(); }
+
+ private:
+  std::condition_variable cv_;
+};
+
+std::shared_ptr<Mutex>
+MutexFactoryImpl::AllocateMutex() {
+  return std::shared_ptr<Mutex>(new MutexImpl());
+}
+
+std::shared_ptr<CondVar>
+MutexFactoryImpl::AllocateCondVar() {
+  return std::shared_ptr<CondVar>(new CondVarImpl());
+}
+
+Status MutexImpl::Lock() {
+  mutex_.lock();
+  return Status::OK();
+}
+
+Status MutexImpl::TryLockFor(int64_t timeout_time) {
+  bool locked = true;
+
+  if (timeout_time == 0) {
+    locked = mutex_.try_lock();
+  } else {
+    // Previously, this code used a std::timed_mutex.  However, this was changed
+    // due to known bugs in gcc versions < 4.9.
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54562
+    //
+    // Since this mutex isn't held for long and only a single mutex is ever
+    // held at a time, it is reasonable to ignore the lock timeout_time here
+    // and only check it when waiting on the condition_variable.
+    mutex_.lock();
+  }
+
+  if (!locked) {
+    // timeout acquiring mutex
+    return Status::Timeout("MutexTimeout");
+  }
+
+  return Status::OK();
+}
+
+Status CondVarImpl::Wait(
+    std::shared_ptr<Mutex> mutex) {
+  auto mutex_impl = reinterpret_cast<MutexImpl*>(mutex.get());
+
+  std::unique_lock<std::mutex> lock(mutex_impl->mutex_, std::adopt_lock);
+  cv_.wait(lock);
+
+  // Make sure unique_lock doesn't unlock mutex when it destructs
+  lock.release();
+
+  return Status::OK();
+}
+
+Status CondVarImpl::WaitFor(
+    std::shared_ptr<Mutex> mutex, int64_t timeout_time) {
+  Status s;
+
+  auto mutex_impl = reinterpret_cast<MutexImpl*>(mutex.get());
+  std::unique_lock<std::mutex> lock(mutex_impl->mutex_, std::adopt_lock);
+
+  if (timeout_time < 0) {
+    // If timeout is negative, do not use a timeout
+    cv_.wait(lock);
+  } else {
+    auto duration = std::chrono::microseconds(timeout_time);
+    auto cv_status = cv_.wait_for(lock, duration);
+
+    // Check if the wait stopped due to timing out.
+    if (cv_status == std::cv_status::timeout) {
+      s = Status::Timeout("MutexTimeout");
+    }
+  }
+
+  // Make sure unique_lock doesn't unlock mutex when it destructs
+  lock.release();
+
+  // CV was signaled, or we spuriously woke up (but didn't time out)
+  return s;
+}
+}  // namespace lock
+}  // namespace slash

--- a/slash/src/rsync.cc
+++ b/slash/src/rsync.cc
@@ -12,9 +12,13 @@ static bool CleanRsyncInfo(const std::string& path) {
   return slash::DeleteDirIfExist(path + kRsyncSubDir);
 }
 
-int StartRsync(const std::string& raw_path, const std::string& module, const std::string& ip, const int port) {
+int StartRsync(const std::string& raw_path,
+               const std::string& module,
+               const std::string& ip,
+               const int port,
+               const std::string& passwd) {
   // Sanity check  
-  if (raw_path.empty() || module.empty()) {
+  if (raw_path.empty() || module.empty() || passwd.empty()) {
     return -1;
   }
   std::string path(raw_path);
@@ -23,6 +27,16 @@ int StartRsync(const std::string& raw_path, const std::string& module, const std
   }
   std::string rsync_path = path + kRsyncSubDir + "/";
   CreatePath(rsync_path);
+
+  // Generate secret file
+  std::string secret_file(rsync_path + kRsyncSecretFile);
+  std::ofstream secret_stream(secret_file.c_str());
+  if (!secret_stream) {
+    log_warn("Open rsync secret file failed!");
+    return -1;
+  }
+  secret_stream << kRsyncUser << ":" << passwd;
+  secret_stream.close();
 
   // Generate conf file
   std::string conf_file(rsync_path + kRsyncConfFile);
@@ -43,6 +57,8 @@ int StartRsync(const std::string& raw_path, const std::string& module, const std
   conf_stream << "pid file = " << rsync_path + kRsyncPidFile << std::endl;
   conf_stream << "list = no" << std::endl;
   conf_stream << "strict modes = no" << std::endl;
+  conf_stream << "auth users = " << kRsyncUser << std::endl;
+  conf_stream << "secrets file = " << secret_file << std::endl;
   conf_stream << "[" << module << "]" << std::endl;
   conf_stream << "path = " << path << std::endl;
   conf_stream << "read only = no" << std::endl;
@@ -115,14 +131,17 @@ int StopRsync(const std::string& raw_path) {
   return ret;
 }
 
-int RsyncSendFile(const std::string& local_file_path, const std::string& remote_file_path, const RsyncRemote& remote) {
+int RsyncSendFile(const std::string& local_file_path,
+                  const std::string& remote_file_path,
+                  const std::string& secret_file_path,
+                  const RsyncRemote& remote) {
   std::stringstream ss;
   ss << """rsync -avP --bwlimit=" << remote.kbps
+    << " --password-file=" << secret_file_path
     << " --port=" << remote.port
     << " " << local_file_path
-    << " " << remote.host
+    << " " << kRsyncUser << "@" << remote.host
     << "::" << remote.module << "/" << remote_file_path;
-
   std::string rsync_cmd = ss.str();
   int ret = system(rsync_cmd.c_str());
   if (ret == 0 || (WIFEXITED(ret) && !WEXITSTATUS(ret))) {
@@ -132,7 +151,10 @@ int RsyncSendFile(const std::string& local_file_path, const std::string& remote_
   return ret;
 }
 
-int RsyncSendClearTarget(const std::string& local_dir_path, const std::string& remote_dir_path, const RsyncRemote& remote) {
+int RsyncSendClearTarget(const std::string& local_dir_path,
+                         const std::string& remote_dir_path,
+                         const std::string& secret_file_path,
+                         const RsyncRemote& remote) {
   if (local_dir_path.empty() || remote_dir_path.empty()) {
     return -2;
   }
@@ -145,8 +167,9 @@ int RsyncSendClearTarget(const std::string& local_dir_path, const std::string& r
   }
   std::stringstream ss;
   ss << "rsync -avP --delete --port=" << remote.port
+    << " --password-file=" << secret_file_path
     << " " << local_dir
-    << " " << remote.host
+    << " " << kRsyncUser << "@" << remote.host
     << "::" << remote.module << "/" << remote_dir;
   std::string rsync_cmd = ss.str();
   int ret = system(rsync_cmd.c_str());

--- a/slash/src/rsync.cc
+++ b/slash/src/rsync.cc
@@ -31,8 +31,11 @@ int StartRsync(const std::string& raw_path, const std::string& module, const std
     log_warn("Open rsync conf file failed!");
     return -1;
   }
-  conf_stream << "uid = root" << std::endl;
-  conf_stream << "gid = root" << std::endl;
+
+  if (geteuid() == 0) {
+    conf_stream << "uid = root" << std::endl;
+    conf_stream << "gid = root" << std::endl;
+  }
   conf_stream << "use chroot = no" << std::endl;
   conf_stream << "max connections = 10" << std::endl;
   conf_stream << "lock file = " << rsync_path + kRsyncLockFile << std::endl;

--- a/slash/src/rsync.cc
+++ b/slash/src/rsync.cc
@@ -120,7 +120,7 @@ int StopRsync(const std::string& raw_path) {
     return 0;
   }
 
-  std::string rsync_stop_cmd = "kill -- -$(ps -o pgid= " + std::to_string(pid) + ")";
+  std::string rsync_stop_cmd = "kill $(ps -o pgid=" + std::to_string(pid) + ")";
   int ret = system(rsync_stop_cmd.c_str());
   if (ret == 0 || (WIFEXITED(ret) && !WEXITSTATUS(ret))) {
     log_info("Stop rsync success!");

--- a/slash/src/scope_record_lock.cc
+++ b/slash/src/scope_record_lock.cc
@@ -1,0 +1,82 @@
+//  Copyright (c) 2017-present The blackwidow Authors.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#include "slash/include/scope_record_lock.h"
+
+namespace slash {
+
+namespace lock {
+
+MultiScopeRecordLock::MultiScopeRecordLock(LockMgr* lock_mgr,
+    const std::vector<std::string>& keys) :
+    lock_mgr_(lock_mgr),
+    keys_(keys) {
+  std::string pre_key;
+  std::sort(keys_.begin(), keys_.end());
+  if (!keys_.empty() &&
+    keys_[0].empty()) {
+    lock_mgr_->TryLock(pre_key);
+  }
+
+  for (const auto& key : keys_) {
+    if (pre_key != key) {
+      lock_mgr_->TryLock(key);
+      pre_key = key;
+    }
+  }
+}
+MultiScopeRecordLock::~MultiScopeRecordLock() {
+  std::string pre_key;
+  if (!keys_.empty() &&
+    keys_[0].empty()) {
+    lock_mgr_->UnLock(pre_key);
+  }
+
+  for (const auto& key : keys_) {
+    if (pre_key != key) {
+      lock_mgr_->UnLock(key);
+      pre_key = key;
+    }
+  }
+}
+
+void MultiRecordLock::Lock(const std::vector<std::string>& keys) {
+  std::vector<std::string> internal_keys = keys;
+  std::sort(internal_keys.begin(), internal_keys.end());
+  // init to be ""
+  std::string pre_key;
+  // consider internal_keys "" "" "a"
+  if (!internal_keys.empty()) {
+    lock_mgr_->TryLock(internal_keys.front());
+    pre_key = internal_keys.front();
+  }
+
+  for (const auto& key : internal_keys) {
+    if (pre_key != key) {
+      lock_mgr_->TryLock(key);
+      pre_key = key;
+    }
+  }
+}
+
+
+void MultiRecordLock::Unlock(const std::vector<std::string>& keys) {
+  std::vector<std::string> internal_keys = keys;
+  std::sort(internal_keys.begin(), internal_keys.end());
+  std::string pre_key;
+  if (!internal_keys.empty()) {
+    lock_mgr_->UnLock(internal_keys.front());
+    pre_key = internal_keys.front();
+  }
+
+  for (const auto& key : internal_keys) {
+    if (pre_key != key) {
+      lock_mgr_->UnLock(key);
+      pre_key = key;
+    }
+  }
+}
+}  // namespace lock
+}  // namespace slash

--- a/slash/src/slash_coding.cc
+++ b/slash/src/slash_coding.cc
@@ -7,12 +7,22 @@
 
 namespace slash {
 
+void EncodeFixed16(char* buf, uint16_t value) {
+  memcpy(buf, &value, sizeof(value));
+}
+
 void EncodeFixed32(char* buf, uint32_t value) {
   memcpy(buf, &value, sizeof(value));
 }
 
 void EncodeFixed64(char* buf, uint64_t value) {
   memcpy(buf, &value, sizeof(value));
+}
+
+void PutFixed16(std::string* dst, uint16_t value) {
+  char buf[sizeof(value)];
+  EncodeFixed16(buf, value);
+  dst->append(buf, sizeof(buf));
 }
 
 void PutFixed32(std::string* dst, uint32_t value) {

--- a/slash/src/slash_mutex.cc
+++ b/slash/src/slash_mutex.cc
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <sys/time.h>
 
+#include <algorithm>
+
 namespace slash {
 
 static void PthreadCall(const char* label, int result) {
@@ -145,7 +147,6 @@ RecordMutex::~RecordMutex() {
   }
   mutex_.Unlock();
 }
-
 
 void RecordMutex::Lock(const std::string &key) {
   mutex_.Lock();

--- a/slash/src/slash_status.cc
+++ b/slash/src/slash_status.cc
@@ -72,6 +72,8 @@ std::string Status::ToString() const {
     case kAuthFailed:
       type = "AuthFailed: ";
       break;
+    case kBusy:
+      type = "Busy:";
     default:
       snprintf(tmp, sizeof(tmp), "Unknown code(%d): ",
           static_cast<int>(code()));

--- a/slash/src/slash_string.cc
+++ b/slash/src/slash_string.cc
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <math.h>
+#include <cmath>
 #include <limits.h>
 #include <unistd.h>
 #include <sys/time.h>

--- a/slash/src/slash_string.cc
+++ b/slash/src/slash_string.cc
@@ -538,6 +538,11 @@ std::string& StringToLower(std::string& ori) {
   return ori;
 }
 
+std::string& StringToUpper(std::string& ori) {
+  std::transform(ori.begin(), ori.end(), ori.begin(), ::toupper);
+  return ori;
+}
+
 std::string IpPortString(const std::string& ip, int port) {
   if (ip.empty()) {
     return std::string();

--- a/slash/src/slash_string.cc
+++ b/slash/src/slash_string.cc
@@ -413,6 +413,22 @@ int string2l(const char *s, size_t slen, long *lval) {
     return 1;
 }
 
+/* Convert a string into a unsigned long. Returns 1 if the string could be parsed into a
+ * (non-overflowing) unsigned long, 0 otherwise. The value will be set to the parsed
+ * value when appropriate. */
+int string2ul(const char *s, size_t slen, unsigned long *lval) {
+    long long llval;
+
+    if (!string2ll(s,slen,&llval))
+        return 0;
+
+    if (llval > ULONG_MAX)
+        return 0;
+
+    *lval = (unsigned long)llval;
+    return 1;
+}
+
 /* Convert a double to a string representation. Returns the number of bytes
  * required. The representation should always be parsable by strtod(3). */
 int d2string(char *buf, size_t len, double value) {


### PR DESCRIPTION
pika版本：v3.3.1
ctrl+c推出后，没有正常关闭rsync，观察日志，有这个错误：
![image](https://user-images.githubusercontent.com/5351555/216842256-2f4de9d6-6355-48b4-bac3-80a48dbc191a.png)
会导致重新启动pika时检查到rsync端口被占用而启动失败。
通过查看源代码，发现在slash中，停止rsync的kill命令有点问题。